### PR TITLE
Adding additional expected vs. observed step in disease progression pipeline

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,6 +1,6 @@
 DATA_DIR=
 RESULTS_DIR=
-RDFS_DIR=/projects/MRC-IEU/research/projects/ieu3/px/xxx/working/
+RDFS_DIR=
 GENOMIC_DATA_DIR=/mnt/storage/private/mrcieu/data/genomic_data/
 THOUSAND_GENOMES_DIR=/mnt/storage/private/mrcieu/data/genomic_data/1000genomes/b37_dbsnp156/
 LDSC_DIR=/mnt/storage/private/mrcieu/data/LDSCORE/b37_dbsnp156/

--- a/R/markdown/disease_progression.Rmd
+++ b/R/markdown/disease_progression.Rmd
@@ -22,7 +22,9 @@ knitr::kable(collider_bias_results)
 ### Expected vs Observed Results
 
 This shows all expected vs. observed results when comparing the incident vs. subsequent GWASes
+
 First table: Expected vs. Observed before adjusted for Collider Bias
+
 Second table: Expected vs. Observed after adjusting with SlopeHunter
 ```{r echo=F}
 original_expected_vs_observed <- vroom::vroom(params$original_expected_vs_observed, show_col_types = F)

--- a/R/markdown/disease_progression.Rmd
+++ b/R/markdown/disease_progression.Rmd
@@ -22,9 +22,14 @@ knitr::kable(collider_bias_results)
 ### Expected vs Observed Results
 
 This shows all expected vs. observed results when comparing the incident vs. subsequent GWASes
+First table: Expected vs. Observed before adjusted for Collider Bias
+Second table: Expected vs. Observed after adjusting with SlopeHunter
 ```{r echo=F}
-expected_vs_observed <- vroom::vroom(params$expected_vs_observed, show_col_types = F)
-knitr::kable(expected_vs_observed)
+original_expected_vs_observed <- vroom::vroom(params$original_expected_vs_observed, show_col_types = F)
+knitr::kable(original_expected_vs_observed)
+
+adjusted_expected_vs_observed <- vroom::vroom(params$adjusted_expected_vs_observed, show_col_types = F)
+knitr::kable(adjusted_expected_vs_observed)
 ```
 
 ### Adjusted Manhattan Plots of GWAS

--- a/snakemake/util/constants.smk
+++ b/snakemake/util/constants.smk
@@ -59,3 +59,5 @@ PIPELINE_DATA_DIR = GENOMIC_DATA_DIR + "/pipeline"
 
 if RDFS_DIR and not RDFS_DIR.endswith("working/"):
     raise ValueError("Please ensure RDFS_DIR ends with working/ to ensure the data gets copied to the correct place")
+if DATA_DIR == RESULTS_DIR:
+    raise ValueError("DATA_DIR and RESULTS_DIR must be different directories")


### PR DESCRIPTION
Doing two calculations:
* Expected vs. Observed before adjusted for Collider Bias
* Expected vs. Observed after adjusting with SlopeHunter

Also, fixing bug ensuring DATA_DIR and RESULTS_DIR can't be the same directory